### PR TITLE
subsys: net: lib: aws_fota: Add AWS_FOTA prefix to Kconfigs

### DIFF
--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -13,7 +13,7 @@ menuconfig AWS_FOTA
 
 if AWS_FOTA
 
-config VERSION_STRING_MAX_LEN
+config AWS_FOTA_VERSION_STRING_MAX_LEN
 	int "Application version string max length"
 	default 10
 
@@ -21,7 +21,7 @@ config AWS_FOTA_PAYLOAD_SIZE
 	int "MQTT payload reception buffer size for AWS IoT Jobs messages"
 	default 1350
 
-config DEVICE_SHADOW_PAYLOAD_SIZE
+config AWS_FOTA_DEVICE_SHADOW_PAYLOAD_SIZE
 	int "MQTT payload transmission buffer size for AWS IoT device shadow updates"
 	default 255
 

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -41,7 +41,7 @@ static enum fota_status fota_state = NONE;
 static u32_t doc_version_number = 1;
 
 /* Buffer for reporting the current application version */
-static char version[CONFIG_VERSION_STRING_MAX_LEN];
+static char version[CONFIG_AWS_FOTA_VERSION_STRING_MAX_LEN];
 
 /* Allocated strings for topics */
 static u8_t notify_next_topic[AWS_JOBS_TOPIC_MAX_LEN];
@@ -86,7 +86,7 @@ static int update_device_shadow_version(struct mqtt_client *const client)
 {
 	struct mqtt_publish_param param;
 	char update_delta_topic[AWS_JOBS_TOPIC_MAX_LEN];
-	u8_t shadow_update_payload[CONFIG_DEVICE_SHADOW_PAYLOAD_SIZE];
+	u8_t shadow_update_payload[CONFIG_AWS_FOTA_DEVICE_SHADOW_PAYLOAD_SIZE];
 
 	int ret = snprintf(update_delta_topic,
 			   sizeof(update_delta_topic),
@@ -424,7 +424,7 @@ int aws_fota_init(struct mqtt_client *const client,
 		return -EINVAL;
 	}
 
-	if (strlen(app_version) >= CONFIG_VERSION_STRING_MAX_LEN) {
+	if (strlen(app_version) >= CONFIG_AWS_FOTA_VERSION_STRING_MAX_LEN) {
 		return -EINVAL;
 	}
 
@@ -438,7 +438,7 @@ int aws_fota_init(struct mqtt_client *const client,
 		return err;
 	}
 
-	strncpy(version, app_version, CONFIG_VERSION_STRING_MAX_LEN);
+	strncpy(version, app_version, CONFIG_AWS_FOTA_VERSION_STRING_MAX_LEN);
 
 	return 0;
 }


### PR DESCRIPTION
Add the prefix AWS_FOTA to Kconfig and change the .c file to use the
correct Kconfig variables.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>